### PR TITLE
Remove clipboard copying feature

### DIFF
--- a/.cursor/rules/yastwai.mdc
+++ b/.cursor/rules/yastwai.mdc
@@ -48,8 +48,8 @@ alwaysApply: true
         - ✅ Commit titles: For each commit
         - 📁 Files Changed: For listing modified files
     - When executing the create-pr.sh script (only when requested):
-        - Always copy the full description to clipboard before opening the browser
-        - Paste the complete clipboard content into GitHub's PR description field
+        - The script will display the PR description in the terminal for reference
+        - Manually copy the description from the terminal if needed
         - Verify the PR has been created with the proper formatting and content
     - For large PRs, use appropriate markdown (headers, lists, code blocks) to enhance readability.
 

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -249,6 +249,14 @@ echo "Title: $PR_TITLE"
 echo "Base branch: $BASE_BRANCH"
 echo "Current branch: $CURRENT_BRANCH"
 
+# Display the PR body for reference instead of copying to clipboard
+echo ""
+echo "PR Description (you can copy this manually if needed):"
+echo "------------------------------------------------------"
+echo "$PR_BODY"
+echo "------------------------------------------------------"
+echo ""
+
 # Open the PR URL in the browser
 if command -v open &> /dev/null; then
     open "$PR_URL"


### PR DESCRIPTION
## 📌 **Overview**
This PR removes the automatic clipboard copying functionality from the PR creation process for better compatibility with non-interactive environments and automation.

## 🔍 **Key Changes**
- Removed clipboard copying instructions from Cursor Rules
- Updated the PR creation script to not rely on clipboard functionality

## 🧩 **Implementation Details**
The changes focus on making the PR process more compatible with automated environments by:
1. Updating the yastwai.mdc rules to remove references to clipboard copying
2. Modifying the create-pr.sh script to display the PR description in the terminal instead of copying to clipboard

## 📝 **Commit Details**
- 📅 Mon Mar 10, 2025: ✅ Update Cursor Rules to remove clipboard copying instructions
- 📅 Mon Mar 10, 2025: ✅ Remove clipboard copying feature from PR creation process

## 📁 **Files Changed**
- .cursor/rules/yastwai.mdc
- scripts/create-pr.sh