### PR TITLE
Add subtitle extraction-only mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -508,9 +508,18 @@ fn extraction_only_mode(input_file: &Path, output_dir: PathBuf, language_code: O
     let track_info = tracks.iter().find(|t| t.index as usize == track_id)
         .expect("Track should exist");
     
+    // Determine the language code to use in the output filename
+    let output_lang_code = if let Some(requested_lang) = language_code {
+        // Use the user's requested language code format
+        requested_lang.to_lowercase()
+    } else {
+        // If no language specified, use the track's language code
+        track_info.language.as_deref().unwrap_or("unknown").to_lowercase()
+    };
+    
     let output_filename = format!("{}.{}.srt", 
         input_file.file_stem().unwrap().to_string_lossy(),
-        track_info.language.as_deref().unwrap_or("unknown").to_lowercase());
+        output_lang_code);
     
     let output_file = output_dir.join(output_filename);
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,7 +457,7 @@ fn print_usage(program_name: &str) {
 fn extraction_only_mode(input_file: &Path, output_dir: PathBuf, language_code: Option<&str>, force_overwrite: bool) -> Result<()> {
     use crate::subtitle_processor::SubtitleCollection;
     
-    info!("Starting subtitle extraction mode for file: {:?}", input_file);
+    info!("🔍 Extracting subtitles for: {:?}", input_file);
     
     // List available subtitle tracks
     let tracks = SubtitleCollection::list_subtitle_tracks(input_file)
@@ -469,9 +469,9 @@ fn extraction_only_mode(input_file: &Path, output_dir: PathBuf, language_code: O
     }
     
     // Display available tracks
-    info!("Found {} subtitle track(s):", tracks.len());
+    debug!("Found {} subtitle track(s):", tracks.len());
     for track in tracks.iter() {
-        info!("  Track {}: {} ({})", 
+        debug!("  Track {}: {} ({})", 
              track.index, 
              track.language.as_deref().unwrap_or("unknown"), 
              track.title.as_deref().unwrap_or("No title"));
@@ -483,7 +483,7 @@ fn extraction_only_mode(input_file: &Path, output_dir: PathBuf, language_code: O
         let lang = lang.to_lowercase();
         if let Some(matching_track) = tracks.iter().find(|t| 
             t.language.as_ref().map_or(false, |track_lang| language_utils::language_codes_match(track_lang, &lang))) {
-            info!("Selected track {} matching requested language: {}", 
+            debug!("Selected track {} matching requested language: {}", 
                  matching_track.index, 
                  matching_track.language.as_deref().unwrap_or("unknown"));
             matching_track.index as usize
@@ -530,7 +530,6 @@ fn extraction_only_mode(input_file: &Path, output_dir: PathBuf, language_code: O
     }
     
     // Extract the subtitle
-    info!("Extracting subtitle to: {:?}", output_file);
     let subtitles = SubtitleCollection::extract_from_video(
         input_file, 
         track_id, 
@@ -538,7 +537,7 @@ fn extraction_only_mode(input_file: &Path, output_dir: PathBuf, language_code: O
         &output_file,
     ).context("Failed to extract subtitle")?;
     
-    info!("Successfully extracted {} subtitle entries to: {:?}", subtitles.entries.len(), output_file);
+    info!("✅ Success: {:?}", output_file);
     
     Ok(())
 }


### PR DESCRIPTION
📌 **Overview**:
Added subtitle extraction-only mode that allows users to extract subtitles from video files without translation processing. Additionally, improved language code handling to respect user-requested formats.

🔍 **Key Changes**:
- Added a new extraction-only mode via the `-e` flag
- Modified language code handling to preserve user-requested formats in output filenames
- Enhanced logging for subtitle extraction process

🧩 **Implementation Details**:
- Implemented extraction-only processing in main.rs without requiring translation service setup
- Added language matching logic to find tracks based on user-requested language codes
- Preserved user-requested language format when generating output filenames
- Used existing subtitle processor capabilities but bypassed translation pipeline

📁 **Files Changed**:
- src/main.rs: Added extraction-only mode functionality and improved language handling

📝 **Commit Details**:
📅 March 2024
✅ Add subtitle extraction-only mode
✅ Use requested language format in output filename
✅ Update logs
