### PR TITLE
Fix special formatting marker appearing in translations

### DIFF
--- a/src/translation_service.rs
+++ b/src/translation_service.rs
@@ -1292,11 +1292,13 @@ impl TranslationService {
                         }
                     }
                 } else if let Some(_entry_num) = current_entry_num {
-                    // Add content to the current entry
-                    if !current_entry_text.is_empty() {
-                        current_entry_text.push('\n');
+                    // Add content to the current entry, skipping the SPECIAL_FORMATTING marker
+                    if line.trim() != "# SPECIAL_FORMATTING #" {
+                        if !current_entry_text.is_empty() {
+                            current_entry_text.push('\n');
+                        }
+                        current_entry_text.push_str(line);
                     }
-                    current_entry_text.push_str(line);
                 }
             }
             


### PR DESCRIPTION
📌 **Overview**:
Remove '# SPECIAL_FORMATTING #' marker from final translations while preserving it as an instruction for the translation service

🔍 **Key Changes**:
- Modified text extraction to filter out special formatting markers
- Preserved marker functionality for translation service instructions

🧩 **Implementation Details**:
- Added condition to skip special formatting marker during line processing
- Maintained marker in input for translation service to handle special formatting properly

📁 **Files Changed**:
- src/translation_service.rs

📝 **Commit Details**:
📅 March 2025
✅ Fix special formatting marker appearing in translations
