### PR TITLE
Suppression des marqueurs SPECIAL_FORMATTING dans les sous-titres finaux

### DIFF
--- a/src/translation_service.rs
+++ b/src/translation_service.rs
@@ -1292,6 +1292,11 @@ impl TranslationService {
                         }
                     }
                 } else if let Some(_entry_num) = current_entry_num {
+                    // Skip the special formatting marker
+                    if line == "# SPECIAL_FORMATTING #" {
+                        continue;
+                    }
+                    
                     // Add content to the current entry
                     if !current_entry_text.is_empty() {
                         current_entry_text.push('\n');
@@ -1433,6 +1438,7 @@ impl TranslationService {
                             let content = individual_result.lines()
                                 .skip_while(|line| !line.starts_with("ENTRY_"))
                                 .skip(1) // Skip the marker line
+                                .filter(|line| *line != "# SPECIAL_FORMATTING #") // Filter out the special formatting marker
                                 .collect::<Vec<&str>>()
                                 .join("\n");
                                 
@@ -1515,6 +1521,7 @@ impl TranslationService {
                             let content = individual_result.lines()
                                 .skip_while(|line| !line.starts_with("ENTRY_"))
                                 .skip(1) // Skip the marker line
+                                .filter(|line| *line != "# SPECIAL_FORMATTING #") // Filter out the special formatting marker
                                 .collect::<Vec<&str>>()
                                 .join("\n");
                                 
@@ -1625,6 +1632,7 @@ impl TranslationService {
                     let content = individual_result.lines()
                         .skip_while(|line| !line.starts_with("ENTRY_"))
                         .skip(1) // Skip the marker line
+                        .filter(|line| *line != "# SPECIAL_FORMATTING #") // Filter out the special formatting marker
                         .collect::<Vec<&str>>()
                         .join("\n");
                         


### PR DESCRIPTION
📌 **Overview**:
Cette PR corrige un problème où les marqueurs "# SPECIAL_FORMATTING #" utilisés pour indiquer au modèle de traduction la présence de formatage spécial restaient dans les sous-titres traduits finaux.

🔍 **Key Changes**:
- Ajout d'un filtre pour supprimer les marqueurs # SPECIAL_FORMATTING # lors de l'extraction du texte traduit
- Maintien de l'ajout des marqueurs lors de l'envoi au modèle pour préserver la fonctionnalité de gestion du formatage spécial

🧩 **Implementation Details**:
- Le filtre a été ajouté à trois endroits où le texte traduit est extrait : lors du traitement par lot
-  lors des pré-traductions individuelles
-  et lors des traductions individuelles après échec de lot
- La solution utilise un simple filtre qui ignore les lignes contenant exactement le marqueur # SPECIAL_FORMATTING #

📁 **Files Changed**:
- src/translation_service.rs

📝 **Commit Details**:
📅 March 2025
✅ Suppression des marqueurs SPECIAL_FORMATTING dans les sous-titres finaux
