### PR TITLE
Fix special formatting marker handling in subtitles

### DIFF
--- a/src/translation_service.rs
+++ b/src/translation_service.rs
@@ -1292,6 +1292,11 @@ impl TranslationService {
                         }
                     }
                 } else if let Some(_entry_num) = current_entry_num {
+                    // Skip the special formatting marker
+                    if line == "# SPECIAL_FORMATTING #" {
+                        continue;
+                    }
+                    
                     // Add content to the current entry
                     if !current_entry_text.is_empty() {
                         current_entry_text.push('\n');
@@ -1433,6 +1438,7 @@ impl TranslationService {
                             let content = individual_result.lines()
                                 .skip_while(|line| !line.starts_with("ENTRY_"))
                                 .skip(1) // Skip the marker line
+                                .filter(|line| *line != "# SPECIAL_FORMATTING #") // Filter out the special formatting marker
                                 .collect::<Vec<&str>>()
                                 .join("\n");
                                 
@@ -1515,6 +1521,7 @@ impl TranslationService {
                             let content = individual_result.lines()
                                 .skip_while(|line| !line.starts_with("ENTRY_"))
                                 .skip(1) // Skip the marker line
+                                .filter(|line| *line != "# SPECIAL_FORMATTING #") // Filter out the special formatting marker
                                 .collect::<Vec<&str>>()
                                 .join("\n");
                                 
@@ -1625,6 +1632,7 @@ impl TranslationService {
                     let content = individual_result.lines()
                         .skip_while(|line| !line.starts_with("ENTRY_"))
                         .skip(1) // Skip the marker line
+                        .filter(|line| *line != "# SPECIAL_FORMATTING #") // Filter out the special formatting marker
                         .collect::<Vec<&str>>()
                         .join("\n");
                         


### PR DESCRIPTION
📌 **Overview**:
This PR removes SPECIAL_FORMATTING markers from the final subtitles output, ensuring cleaner subtitle text.

🔍 **Key Changes**:
- Skip special formatting markers when parsing subtitle entries
- Filter out special formatting markers from processed subtitle content

🧩 **Implementation Details**:
- Added filtering of '# SPECIAL_FORMATTING #' markers in multiple places where subtitle content is processed
- Implemented consistent handling across different translation methods to ensure no markers appear in final output

📁 **Files Changed**:
- src/translation_service.rs

📝 **Commit Details**:
📅 March 2025
✅ Removal of SPECIAL_FORMATTING markers in final subtitles
