### PR TITLE
Fix Ollama provider URL scheme handling

### DIFF
--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -298,7 +298,15 @@ impl Ollama {
     /// Create a new Ollama client with the specified base URL
     pub fn new(host: impl Into<String>, port: u16) -> Self {
         let host = host.into();
-        let base_url = format!("{}:{}", host, port);
+        
+        // Check if the host already has a scheme
+        let base_url = if host.starts_with("http://") || host.starts_with("https://") {
+            // If the host already includes a scheme, just append the port
+            format!("{}:{}", host, port)
+        } else {
+            // Otherwise, add the http:// scheme and port
+            format!("http://{}:{}", host, port)
+        };
         
         Self {
             base_url,
@@ -708,7 +716,7 @@ impl Ollama {
     
     /// Get the Ollama API version
     pub async fn version(&self) -> Result<String> {
-        let url = format!("{}:{}/api/version", self.base_url, 11434);
+        let url = format!("{}/api/version", self.base_url);
         let response: serde_json::Value = self.client.get(&url)
             .send()
             .await

--- a/tests/unit/providers_tests.rs
+++ b/tests/unit/providers_tests.rs
@@ -76,7 +76,7 @@ async fn test_ollama_provider_withLocalServer_shouldGenerate() {
         return;
     }
     
-    let request = GenerationRequest::new("llama2", "Hello, world!")
+    let request = GenerationRequest::new("gemma3:27b", "Hello, world!")
         .system("You are a helpful assistant.")
         .temperature(0.7);
     
@@ -106,7 +106,7 @@ async fn test_ollama_provider_withLocalServer_shouldChat() {
         ChatMessage { role: "user".to_string(), content: "Hello, world!".to_string() }
     ];
     
-    let request = ChatRequest::new("llama2", messages)
+    let request = ChatRequest::new("gemma3:27b", messages)
         .system("You are a helpful assistant.")
         .temperature(0.7);
     


### PR DESCRIPTION
## 📌 Overview
This PR fixes an issue with URL scheme handling in the Ollama provider and updates tests to use an available model.

## 🔍 Key Changes
- Fixed URL scheme handling in Ollama provider
- Updated Ollama tests to use available model
- Removed hardcoded port in version method

## 🧩 Implementation Details
- Added check for existing URL scheme in the Ollama client constructor
- Simplified version endpoint URL construction by using the base URL

## 🤖 AI Model
claude-3.7-sonnet-thinking

