### PR TITLE
fix(ollama): Correct URL construction for Ollama API requests

### DIFF
--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -299,12 +299,28 @@ impl Ollama {
     pub fn new(host: impl Into<String>, port: u16) -> Self {
         let host = host.into();
         
-        // Check if the host already has a scheme
+        // Construct a proper URL with scheme and port
         let base_url = if host.starts_with("http://") || host.starts_with("https://") {
-            // If the host already includes a scheme, just append the port
-            format!("{}:{}", host, port)
+            // If the host already has a scheme
+            let url_parts: Vec<&str> = host.split("://").collect();
+            if url_parts.len() == 2 {
+                let scheme = url_parts[0];
+                let host_part = url_parts[1];
+                
+                // Check if host_part already contains a port
+                if host_part.contains(":") {
+                    // Already has a port, use as is
+                    host
+                } else {
+                    // No port, append it
+                    format!("{}://{}:{}", scheme, host_part, port)
+                }
+            } else {
+                // Malformed URL, fallback to safe default
+                format!("http://localhost:{}", port)
+            }
         } else {
-            // Otherwise, add the http:// scheme and port
+            // No scheme, add http:// and port
             format!("http://{}:{}", host, port)
         };
         


### PR DESCRIPTION
## 📌 Overview
This PR fixes an issue with URL construction in the Ollama provider that was causing 'URL scheme is not allowed' errors. The solution improves how URLs with and without schemes are handled.

## 🔍 Key Changes
- Fixed URL construction in Ollama client to properly handle hosts with and without schemes
- Implemented robust URL parsing to correctly handle hosts that already have ports
- Added fallback to a safe default URL in case of malformed inputs

## 🧩 Implementation Details
- Split the host into scheme and host parts for better parsing
- Added specific handling for hosts that already include port numbers
- Made the URL construction logic more comprehensive to handle all scenarios

## 🤖 AI Model
claude-3.7-sonnet-thinking

